### PR TITLE
User settings page responsivity + small fixes

### DIFF
--- a/frontend/app/movies/[id]/movieInfo.tsx
+++ b/frontend/app/movies/[id]/movieInfo.tsx
@@ -56,7 +56,7 @@ export const MovieInfo = async ({ movie }: { movie: Movie }) => {
             {session && <StarRating />}
           </div>
           <div className="movie-basic-data">
-            <h1>{movie.title}</h1>
+            <h2 className="h1">{movie.title}</h2>
 
             <div className="movie-data-row">
               {movie.directors.length > 0 ? (

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -4,7 +4,7 @@ export default function NotFound() {
   return (
     <main className="not-found-main">
       <h2>Error 404: Page Not Found</h2>
-      <h6>Oops! It seems like you&rsquo;ve stumbled upon a missing scene.</h6>
+      <h3 className="h6">Oops! It seems like you&rsquo;ve stumbled upon a missing scene.</h3>
 
       <Link href="/">
         <button>Go back to home</button>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -72,39 +72,46 @@ export default async function Home({ searchParams }: { searchParams?: { genre: s
     <main>
       <div className="dropdown-button">
         <p>Genre</p>
-        <Dropdown selected={selectedGenre ?? "All"}>{await getGenres()}</Dropdown>
+        <Dropdown
+          width={200}
+          selected={selectedGenre ?? "All"}
+        >
+          {await getGenres()}
+        </Dropdown>
       </div>
 
-      <Section
-        header={
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <h3>{"New Movies"}</h3>
-            <Link href={"/new"}>See all</Link>
-          </div>
-        }
-      >
-        <div className="poster-list">{await getPosters("new", selectedGenre)}</div>
-      </Section>
-      <Section
-        header={
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <h3>{"Popular Movies"}</h3>
-            <Link href={"/popular"}>See all</Link>
-          </div>
-        }
-      >
-        <div className="poster-list">{await getPosters("popular", selectedGenre)}</div>
-      </Section>
-      <Section
-        header={
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <h3>{"Best Rated Movies"}</h3>
-            <Link href={"/bestrated"}>See all</Link>
-          </div>
-        }
-      >
-        <div className="poster-list">{await getPosters("bestrated", selectedGenre)}</div>
-      </Section>
+      <div className="section-wrapper">
+        <Section
+          header={
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <h2 className="h3">New Movies</h2>
+              <Link href="/new">See all</Link>
+            </div>
+          }
+        >
+          <div className="poster-list">{await getPosters("new", selectedGenre)}</div>
+        </Section>
+        <Section
+          header={
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <h2 className="h3">Popular Movies</h2>
+              <Link href="/popular">See all</Link>
+            </div>
+          }
+        >
+          <div className="poster-list">{await getPosters("popular", selectedGenre)}</div>
+        </Section>
+        <Section
+          header={
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <h2 className="h3">Best Rated Movies</h2>
+              <Link href="/bestrated">See all</Link>
+            </div>
+          }
+        >
+          <div className="poster-list">{await getPosters("bestrated", selectedGenre)}</div>
+        </Section>
+      </div>
     </main>
   );
 }

--- a/frontend/app/persons/[id]/page.tsx
+++ b/frontend/app/persons/[id]/page.tsx
@@ -65,10 +65,12 @@ export default async function Person({ params }: { params: { id: string } }) {
           </div>
 
           <div className="person-info">
-            <span className="person-birthday">
-              {person.birthday ? formatDate(person.birthday) : ""} -{" "}
-              {person.deathday ? formatDate(person.deathday) : ""}
-            </span>
+            {(person.birthday || person.deathday) && (
+              <span className="person-birthday">
+                {person.birthday ? formatDate(person.birthday) : ""} -{" "}
+                {person.deathday ? formatDate(person.deathday) : ""}
+              </span>
+            )}
             <h1>{person.name ? person.name : "No name"}</h1>
             <p className="person-description">{person.biography ? person.biography : "No biography"}</p>
           </div>

--- a/frontend/app/profile/settings/page.tsx
+++ b/frontend/app/profile/settings/page.tsx
@@ -8,7 +8,7 @@ export default async function Profile() {
   const session = await getServerSession(authOptions);
   const profileHeader = (
     <div>
-      <h2>Settings</h2>
+      <h2 className="h3">Settings</h2>
     </div>
   );
   if (!session) {

--- a/frontend/app/profile/settings/page.tsx
+++ b/frontend/app/profile/settings/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/authOptions";
 import { Section } from "@/components/section";
-import { ProfileSettings } from "@/app/profile/settings/profileSettings";
+import { ProfileSettings } from "./profileSettings";
 
 export default async function Profile() {
   const session = await getServerSession(authOptions);

--- a/frontend/app/profile/settings/page.tsx
+++ b/frontend/app/profile/settings/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/authOptions";
 import { Section } from "@/components/section";
-import { ProfileSettings } from "@/components/profileSettings";
+import { ProfileSettings } from "@/app/profile/settings/profileSettings";
 
 export default async function Profile() {
   const session = await getServerSession(authOptions);

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -438,42 +438,39 @@ export const ProfileSettings = ({ user }: Props) => {
               isOpen={isOpen}
               closeModal={closeModal}
               content={
-                <>
-                  <div className="profile-settings-modal-content">
-                    <div>
-                      <h3>Are you sure you want to delete your account?</h3>
+                <div className="profile-settings-modal-content">
+                  <div>
+                    <h3>Are you sure you want to delete your account?</h3>
 
-                      <p className="description">
-                        If you delete your account, all your lists, reviews and other data will be destroyed
-                        permanently.
+                    <p className="description">
+                      If you delete your account, all your lists, reviews and other data will be destroyed permanently.
+                    </p>
+
+                    {error && (
+                      <p
+                        className="error-text"
+                        style={{ display: "flex", justifyContent: "center", padding: "5px" }}
+                      >
+                        {error}
                       </p>
-
-                      {error && (
-                        <p
-                          className="error-text"
-                          style={{ display: "flex", justifyContent: "center", padding: "5px" }}
-                        >
-                          {error}
-                        </p>
-                      )}
-                    </div>
-                    <div className="profile-settings-modal-buttons">
-                      <button
-                        onClick={() => {
-                          setIsOpen(false);
-                        }}
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="button-pink"
-                        onClick={handleDelete}
-                      >
-                        Delete Account
-                      </button>
-                    </div>
+                    )}
                   </div>
-                </>
+                  <div className="profile-settings-modal-buttons">
+                    <button
+                      onClick={() => {
+                        setIsOpen(false);
+                      }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="button-pink"
+                      onClick={handleDelete}
+                    >
+                      Delete Account
+                    </button>
+                  </div>
+                </div>
               }
             />
           </div>

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -429,35 +429,38 @@ export const ProfileSettings = ({ user }: Props) => {
               content={
                 <>
                   <div className="profile-settings-modal-content">
-                    <h3>Are you sure you want to delete your account?</h3>
+                    <div>
+                      <h3>Are you sure you want to delete your account?</h3>
 
-                    <p className="description">
-                      If you delete your account, all your lists, reviews and other data will be destroyed permanently.
-                    </p>
-                  </div>
+                      <p className="description">
+                        If you delete your account, all your lists, reviews and other data will be destroyed
+                        permanently.
+                      </p>
 
-                  {error && (
-                    <p
-                      className="error-text"
-                      style={{ display: "flex", justifyContent: "center", padding: "5px" }}
-                    >
-                      {error}
-                    </p>
-                  )}
-                  <div className="profile-settings-modal-buttons">
-                    <button
-                      onClick={() => {
-                        setIsOpen(false);
-                      }}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      className="button-pink"
-                      onClick={handleDelete}
-                    >
-                      Delete Account
-                    </button>
+                      {error && (
+                        <p
+                          className="error-text"
+                          style={{ display: "flex", justifyContent: "center", padding: "5px" }}
+                        >
+                          {error}
+                        </p>
+                      )}
+                    </div>
+                    <div className="profile-settings-modal-buttons">
+                      <button
+                        onClick={() => {
+                          setIsOpen(false);
+                        }}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="button-pink"
+                        onClick={handleDelete}
+                      >
+                        Delete Account
+                      </button>
+                    </div>
                   </div>
                 </>
               }

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState } from "react";
-import { Facebook, Instagram, Twitter, Smile } from "react-feather";
+import { Facebook, Instagram, Twitter, Smile, Eye, EyeOff } from "react-feather";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
@@ -53,6 +53,7 @@ export const ProfileSettings = ({ user }: Props) => {
   const [activeUsername, setActiveUsername] = useState(false);
   const [activeEmail, setActiveEmail] = useState(false);
   const [activePassword, setActivePassword] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const { update } = useSession();
@@ -379,14 +380,23 @@ export const ProfileSettings = ({ user }: Props) => {
             >
               <label htmlFor="password">Password</label>
               <div className="profile-settings-input">
-                <input
-                  id="password"
-                  type="password"
-                  {...passwordRegister("password")}
-                  required
-                  placeholder="Set new password"
-                />
-
+                <div className="password-input-wrapper">
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    {...passwordRegister("password")}
+                    required
+                    placeholder="Set new password"
+                  />
+                  <button
+                    className="form-group-icon button-transparent"
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    tabIndex={-1}
+                  >
+                    {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+                  </button>
+                </div>
                 <button type="submit">Save</button>
               </div>
               <div>

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -7,7 +7,7 @@ import { useForm } from "react-hook-form";
 import { signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import type { User } from "next-auth";
-import Modal from "./modal";
+import Modal from "@/components/modal";
 
 interface Props {
   user: User;
@@ -56,7 +56,9 @@ export const ProfileSettings = ({ user }: Props) => {
   const [error, setError] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const { update } = useSession();
+
   const router = useRouter();
+
   const handleDelete = async () => {
     try {
       const response = await fetch(`/api/users/delete`, {
@@ -244,177 +246,190 @@ export const ProfileSettings = ({ user }: Props) => {
   };
 
   return (
-    <div className="profile-card">
-      <div className="profile-card-left">
-        <Smile size={200} />
+    <div className="profile-settings">
+      <div className="profile-settings-left">
+        <Smile
+          size={200}
+          strokeWidth={1}
+          color={"grey"}
+        />
+
         <div>
           <h3>Description</h3>
           <textarea rows={5} />
         </div>
+
         <h3>Social Media</h3>
-        <div className="profile-card-social-media">
-          <Twitter size={20} />
-          <input
-            type="text"
-            value={"@username"}
-            readOnly
-          />
-          <Instagram size={20} />
-          <input
-            type="text"
-            value={"@username"}
-            readOnly
-          />
-          <Facebook size={20} />
-          <input
-            type="text"
-            value={"@username"}
-            readOnly
-          />
+        <div className="profile-settings-social-media">
+          <div className="social-media-row pink">
+            <Twitter />
+            <input
+              type="text"
+              value={"@username"}
+              readOnly
+            />
+          </div>
+          <div className="social-media-row yellow">
+            <Instagram />
+            <input
+              type="text"
+              value={"@username"}
+              readOnly
+            />
+          </div>
+          <div className="social-media-row cyan">
+            <Facebook />
+            <input
+              type="text"
+              value={"@username"}
+              readOnly
+            />
+          </div>
         </div>
       </div>
-      <div className="profile-card-right">
-        <div className="profile-card-content-divider">
+      <div className="profile-settings-right">
+        <div className="profile-settings-divider">
           <h3>User Information</h3>
-          <p className="description">Here you can change your username, email or password </p>
+          <p className="description">Here you can change your username, email or password.</p>
 
           {activeUsername ? (
             <form
               onSubmit={handleUsernameChange(handleUsernameSubmit)}
-              className="profile-card-element"
+              className="profile-settings-wrapper"
             >
-              <label
-                className="profile-card-label"
-                htmlFor="username"
-              >
-                Username
-              </label>
-              <input
-                id="username"
-                type="text"
-                {...usernameRegister("username")}
-                required
-              />
+              <label htmlFor="username">Username</label>
+              <div className="profile-settings-input">
+                <input
+                  id="username"
+                  type="text"
+                  {...usernameRegister("username")}
+                  required
+                />
 
-              <button type="submit">Save</button>
+                <button type="submit">Save</button>
+              </div>
               <div>
                 {error && <p className="error-text">{error}</p>}
                 {errorsUsername.username && <p className="error-text">{errorsUsername.username.message}</p>}
               </div>
             </form>
           ) : (
-            <div className="profile-card-element">
-              <label className="profile-card-label">Username</label>
-              <p>{user.username}</p>
-              <button
-                onClick={() => {
-                  setActiveUsername(!activeUsername);
-                  setActiveEmail(false);
-                  setActivePassword(false);
-                  resetAllFields();
-                }}
-              >
-                Edit
-              </button>
+            <div className="profile-settings-wrapper">
+              <label>Username</label>
+              <div className="profile-settings-input">
+                <p>{user.username}</p>
+                <button
+                  onClick={() => {
+                    setActiveUsername(!activeUsername);
+                    setActiveEmail(false);
+                    setActivePassword(false);
+                    resetAllFields();
+                  }}
+                >
+                  Edit
+                </button>
+              </div>
             </div>
           )}
           {activeEmail ? (
             <form
               onSubmit={handleEmailChange(handleEmailSubmit)}
-              className="profile-card-element"
+              className="profile-settings-wrapper"
             >
-              <label
-                className="profile-card-label"
-                htmlFor="email"
-              >
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                {...emailRegister("email")}
-                required
-              />
+              <label htmlFor="email">Email</label>
+              <div className="profile-settings-input">
+                <input
+                  id="email"
+                  type="email"
+                  {...emailRegister("email")}
+                  required
+                />
 
-              <button type="submit">Save</button>
+                <button type="submit">Save</button>
+              </div>
               <div>
                 {error && <p className="error-text">{error}</p>}
                 {errorsEmail.email && <p className="error-text">{errorsEmail.email.message}</p>}
               </div>
             </form>
           ) : (
-            <div className="profile-card-element">
-              <label className="profile-card-label">Email</label>
-              <p>{user.email}</p>
-              <button
-                onClick={() => {
-                  setActiveUsername(false);
-                  setActiveEmail(!activeEmail);
-                  setActivePassword(false);
-                  resetAllFields();
-                }}
-              >
-                Edit
-              </button>
+            <div className="profile-settings-wrapper">
+              <label>Email</label>
+
+              <div className="profile-settings-input">
+                <p>{user.email}</p>
+                <button
+                  onClick={() => {
+                    setActiveUsername(false);
+                    setActiveEmail(!activeEmail);
+                    setActivePassword(false);
+                    resetAllFields();
+                  }}
+                >
+                  Edit
+                </button>
+              </div>
             </div>
           )}
           {activePassword ? (
             <form
               onSubmit={handlePasswordChange(handlePasswordSubmit)}
-              className="profile-card-element"
+              className="profile-settings-wrapper"
             >
-              <label
-                className="profile-card-label"
-                htmlFor="password"
-              >
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                {...passwordRegister("password")}
-                required
-                placeholder="Set new password"
-              />
+              <label htmlFor="password">Password</label>
+              <div className="profile-settings-input">
+                <input
+                  id="password"
+                  type="password"
+                  {...passwordRegister("password")}
+                  required
+                  placeholder="Set new password"
+                />
 
-              <button type="submit">Save</button>
+                <button type="submit">Save</button>
+              </div>
               <div>
                 {error && <p className="error-text">{error}</p>}
                 {errorsPassword.password && <p className="error-text">{errorsPassword.password.message}</p>}
               </div>
             </form>
           ) : (
-            <div className="profile-card-element">
-              <label className="profile-card-label">Password</label>
-              <p>xxxxxxxxxxxxxxxxxxx</p>
-              <button
-                onClick={() => {
-                  setActiveUsername(false);
-                  setActiveEmail(false);
-                  setActivePassword(!activePassword);
-                  resetAllFields();
-                }}
-              >
-                Edit
-              </button>
+            <div className="profile-settings-wrapper">
+              <label>Password</label>
+
+              <div className="profile-settings-input">
+                <p>************</p>
+                <button
+                  onClick={() => {
+                    setActiveUsername(false);
+                    setActiveEmail(false);
+                    setActivePassword(!activePassword);
+                    resetAllFields();
+                  }}
+                >
+                  Edit
+                </button>
+              </div>
             </div>
           )}
-          <div className="profile-card-element">
-            <label className="profile-card-label">Delete Account</label>
-            <p className="description">Permanently delete your account</p>
-            <button
-              className="button-pink"
-              onClick={() => setIsOpen(true)}
-            >
-              Delete
-            </button>
+          <div className="profile-settings-wrapper">
+            <label>Delete Account</label>
+            <div className="profile-settings-input">
+              <p className="description">Permanently delete your account.</p>
+              <button
+                className="button-pink"
+                onClick={() => setIsOpen(true)}
+              >
+                Delete
+              </button>
+            </div>
             <Modal
               isOpen={isOpen}
               closeModal={closeModal}
               content={
                 <>
-                  <div className="profile-card-modal-content">
-                    <h3>Are you sure you want to delete your account ?</h3>
+                  <div className="profile-settings-modal-content">
+                    <h3>Are you sure you want to delete your account?</h3>
 
                     <p className="description">
                       If you delete your account, all your lists, reviews and other data will be destroyed permanently.
@@ -429,7 +444,7 @@ export const ProfileSettings = ({ user }: Props) => {
                       {error}
                     </p>
                   )}
-                  <div className="profile-card-modal-buttons">
+                  <div className="profile-settings-modal-buttons">
                     <button
                       onClick={() => {
                         setIsOpen(false);
@@ -449,7 +464,7 @@ export const ProfileSettings = ({ user }: Props) => {
             />
           </div>
         </div>
-        <div className="profile-card-content-divider">
+        <div className="profile-settings-divider">
           <h3>Profile Privacy</h3>
           <p className="description">Here you can choose who can see your profile.</p>
           <form>
@@ -483,10 +498,10 @@ export const ProfileSettings = ({ user }: Props) => {
             </label>
           </form>
         </div>
-        <div className="profile-card-content-divider">
+        <div className="profile-settings-divider">
           <h3>Content Filter</h3>
           <p className="description">
-            Here you can choose to filter content and make your movie browsing experience more suitable for your needs
+            Here you can choose to filter content and make your movie browsing experience more suitable for your needs.
           </p>
           <form>
             <label className="label-row">

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -255,11 +255,11 @@ export const ProfileSettings = ({ user }: Props) => {
         />
 
         <div>
-          <h3>Description</h3>
+          <h3 className="h5">Description</h3>
           <textarea rows={5} />
         </div>
 
-        <h3>Social Media</h3>
+        <h3 className="h5">Social Media</h3>
         <div className="profile-settings-social-media">
           <div className="social-media-row pink">
             <Twitter />

--- a/frontend/app/profile/settings/profileSettings.tsx
+++ b/frontend/app/profile/settings/profileSettings.tsx
@@ -254,7 +254,7 @@ export const ProfileSettings = ({ user }: Props) => {
           color={"grey"}
         />
 
-        <div>
+        <div style={{ marginBottom: "20px" }}>
           <h3 className="h5">Description</h3>
           <textarea rows={5} />
         </div>
@@ -290,6 +290,7 @@ export const ProfileSettings = ({ user }: Props) => {
       <div className="profile-settings-right">
         <div className="profile-settings-divider">
           <h3>User Information</h3>
+
           <p className="description">Here you can change your username, email or password.</p>
 
           {activeUsername ? (
@@ -415,7 +416,7 @@ export const ProfileSettings = ({ user }: Props) => {
           <div className="profile-settings-wrapper">
             <label>Delete Account</label>
             <div className="profile-settings-input">
-              <p className="description">Permanently delete your account.</p>
+              <p>Permanently delete your account.</p>
               <button
                 className="button-pink"
                 onClick={() => setIsOpen(true)}

--- a/frontend/app/users/[id]/favorites/page.tsx
+++ b/frontend/app/users/[id]/favorites/page.tsx
@@ -21,9 +21,9 @@ export default async function userFavorites({ params }: { params: { id: string }
     <main>
       <Section
         header={
-          <h3 className="yellow-name-header">
+          <h2 className="yellow-name-header h3">
             <Link href={"/users/" + params.id}>{user.username}</Link>&rsquo;s favorites
-          </h3>
+          </h2>
         }
       >
         {favorites.length > 0 ? <MovieList movies={shuffleArray(favorites)} /> : <p>No favorite movies yet.</p>}

--- a/frontend/app/users/[id]/friends/page.tsx
+++ b/frontend/app/users/[id]/friends/page.tsx
@@ -15,9 +15,9 @@ export default async function userFriends({ params }: { params: { id: string } }
     <main>
       <Section
         header={
-          <h3 className="yellow-name-header">
+          <h2 className="yellow-name-header h3">
             <Link href={"/users/" + params.id}>{user.username}</Link>&rsquo;s friends
-          </h3>
+          </h2>
         }
       >
         <></>

--- a/frontend/app/users/[id]/lists/[listId]/page.tsx
+++ b/frontend/app/users/[id]/lists/[listId]/page.tsx
@@ -15,9 +15,9 @@ export default async function userFriends({ params }: { params: { id: string; li
     <main>
       <Section
         header={
-          <h3 className="yellow-name-header">
+          <h2 className="yellow-name-header h3">
             <Link href={"/users/" + params.id}>{user.username}</Link>&rsquo;s list name
-          </h3>
+          </h2>
         }
       >
         <></>

--- a/frontend/app/users/[id]/page.tsx
+++ b/frontend/app/users/[id]/page.tsx
@@ -32,14 +32,14 @@ export default async function userProfile({ params }: { params: { id: string } }
 
   const userFavoriteHeader = (
     <div style={{ display: "inline-flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
-      <h5>{user.username}&rsquo;s favorites</h5>
+      <h3 className="h5">{user.username}&rsquo;s favorites</h3>
       <Link href={`/users/${params.id}/favorites`}>See all</Link>
     </div>
   );
 
   const userReviewsHeader = (
     <div style={{ display: "inline-flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
-      <h5>Latest reviews</h5>
+      <h3 className="h5">Latest reviews</h3>
       <Link href={`/users/${params.id}/reviews`}>See all</Link>
     </div>
   );
@@ -72,7 +72,7 @@ export default async function userProfile({ params }: { params: { id: string } }
         {/* User-made lists */}
         <div className="section">
           <div className="list-header">
-            <h5>Lists</h5>
+            <h3 className="h5">Lists</h3>
           </div>
           <div className="list-wrapper">
             {exampleLists.map(list => (

--- a/frontend/app/users/[id]/profileInfo.tsx
+++ b/frontend/app/users/[id]/profileInfo.tsx
@@ -15,11 +15,11 @@ export const ProfileInfo = async ({ userId }: ProfileInfoProps) => {
 
   return (
     <div className="profile-info">
-      <h5>{user?.username}</h5>
+      <h2 className="h4">{user?.username}</h2>
       <div style={{ backgroundColor: "grey", width: "150px", height: "150px", borderRadius: "50%" }} />
 
       <div>
-        <h6>Description</h6>
+        <h3 className="h5">Description</h3>
         <p className="profile-description">
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Facilis atque maxime repudiandae quasi sunt delectus
           perferendis, provident pariatur reprehenderit iure quas officia mollitia, corporis ipsa.
@@ -27,7 +27,7 @@ export const ProfileInfo = async ({ userId }: ProfileInfoProps) => {
       </div>
 
       <div className="full-width">
-        <h6>Social media</h6>
+        <h3 className="h5">Social media</h3>
         <div className="profile-social-media">
           <div>
             <Twitter color="#d75eb5" />
@@ -49,7 +49,7 @@ export const ProfileInfo = async ({ userId }: ProfileInfoProps) => {
       <div className="full-width">
         <div className="profile-friend-list">
           <div className="friends-title">
-            <h5>Friends</h5>
+            <h3 className="h5">Friends</h3>
             <Link href={`/users/${userId}/friends`}>See all</Link>
           </div>
 

--- a/frontend/app/users/[id]/reviews/page.tsx
+++ b/frontend/app/users/[id]/reviews/page.tsx
@@ -16,9 +16,9 @@ export default async function userReviews({ params }: { params: { id: string } }
     <main>
       <Section
         header={
-          <h3 className="yellow-name-header">
+          <h2 className="yellow-name-header h3">
             <Link href={"/users/" + params.id}>{user.username}</Link>&rsquo;s reviews
-          </h3>
+          </h2>
         }
       >
         <div className="review-thumbnail-wrapper">

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -36,7 +36,7 @@ export const Header = () => {
         href="/"
         className="logo"
       >
-        <h4>🍿FilmFellow</h4>
+        <h1 className="h4">🍿FilmFellow</h1>
       </Link>
 
       <nav className="main-nav highlight-nav">

--- a/frontend/cypress/e2e/movies.cy.ts
+++ b/frontend/cypress/e2e/movies.cy.ts
@@ -2,7 +2,7 @@ describe("Movie page tests", () => {
   it("Basic movie page test", () => {
     cy.visit("/movies/278");
     cy.location("pathname").should("eq", "/movies/278");
-    cy.get("h1").contains("The Shawshank Redemption").should("be.visible");
+    cy.get("h2").contains("The Shawshank Redemption").should("be.visible");
     cy.get(".movie-data-row>p").first().contains("Frank Darabont").should("be.visible");
     cy.get(".movie-data-row>p").eq(1).contains("1994").should("be.visible");
     cy.get(".movie-data-row>p").eq(2).contains("R").should("be.visible");
@@ -19,7 +19,7 @@ describe("Movie page tests", () => {
 
   it("Second Basic movie page test", () => {
     cy.visit("/movies/13");
-    cy.get("h1").contains("Forrest Gump");
+    cy.get("h2").contains("Forrest Gump");
     cy.get(".movie-data-row>p").first().contains("Zemeckis").should("be.visible");
     cy.get(".movie-data-row>p").eq(1).contains("1994").should("be.visible");
     cy.get(".movie-data-row>p").eq(2).contains("PG-13").should("be.visible");
@@ -67,7 +67,7 @@ describe("Logged in movie page tests", () => {
   it("Logged movie page test", () => {
     cy.login(email, password);
     cy.visit("/movies/13");
-    cy.get("h1").contains("Forrest Gump");
+    cy.get("h2").contains("Forrest Gump");
     cy.get(".movie-data-row>p").first().contains("Zemeckis").should("be.visible");
     cy.get(".movie-data-row>p").eq(1).contains("1994").should("be.visible");
     cy.get(".movie-data-row>p").eq(2).contains("PG-13").should("be.visible");

--- a/frontend/cypress/e2e/profileSettings.cy.ts
+++ b/frontend/cypress/e2e/profileSettings.cy.ts
@@ -6,6 +6,7 @@ describe("Profile page tests", () => {
   };
 
   const newEmail = "newMail@gmail.com";
+  const newPassword = "Newpassword1!";
 
   before("Register new user for profile page testing", () => {
     cy.register(newUser.email, newUser.password);
@@ -211,13 +212,13 @@ describe("Profile page tests", () => {
       .find("button")
       .should("be.visible")
       .click();
-    cy.get('input[name="password"]').type("Newpassword1!");
+    cy.get('input[name="password"]').type(newPassword);
     cy.get('button[type="submit"]').click();
     cy.location("pathname").should("eq", "/profile/settings");
   });
 
   it("Delete user confirmation modal in the profile page and press cancel", () => {
-    cy.login(newEmail, "Newpassword1!");
+    cy.login(newEmail, newPassword);
     cy.visit("/profile/settings");
     cy
       .get(".profile-settings-right")
@@ -237,7 +238,7 @@ describe("Profile page tests", () => {
   });
 
   it("Delete user confirmation modal in the profile page and successfully delete user", () => {
-    cy.login(newEmail, "Newpassword1!");
+    cy.login(newEmail, newPassword);
     cy.visit("/profile/settings");
     cy
       .get(".profile-settings-right")

--- a/frontend/cypress/e2e/profileSettings.cy.ts
+++ b/frontend/cypress/e2e/profileSettings.cy.ts
@@ -5,6 +5,8 @@ describe("Profile page tests", () => {
     password: "Password1!",
   };
 
+  const newEmail = "newMail@gmail.com";
+
   before("Register new user for profile page testing", () => {
     cy.register(newUser.email, newUser.password);
   });
@@ -24,11 +26,11 @@ describe("Profile page tests", () => {
   it("Try to change username in the profile page without value", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .first()
       .should("be.visible")
       .find("button")
@@ -43,11 +45,11 @@ describe("Profile page tests", () => {
   it("Try to change username in the profile page to something that doesnt meet the requirements", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .first()
       .should("be.visible")
       .find("button")
@@ -63,11 +65,11 @@ describe("Profile page tests", () => {
   it("Try to change username in the profile page as existing one", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .first()
       .should("be.visible")
       .find("button")
@@ -83,31 +85,31 @@ describe("Profile page tests", () => {
   it("Change username successfully in the profile page", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .first()
       .should("be.visible")
       .find("button")
       .should("be.visible")
       .click();
     cy.get('input[name="username"]').clear();
-    cy.get('input[name="username"]').type("newUsername");
+    cy.get('input[name="username"]').type(newUser.username);
     cy.get('button[type="submit"]').click();
-    cy.contains("newUsername").should("be.visible");
+    cy.contains(newUser.username).should("be.visible");
     cy.location("pathname").should("eq", "/profile/settings");
   });
 
   it("Try to change email in the profile page without value", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(1)
       .should("be.visible")
       .find("button")
@@ -122,11 +124,11 @@ describe("Profile page tests", () => {
   it("Try to change email in the profile page as existing one", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(1)
       .should("be.visible")
       .find("button")
@@ -142,31 +144,31 @@ describe("Profile page tests", () => {
   it("Change email successfully in the profile page", () => {
     cy.login(newUser.email, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(1)
       .should("be.visible")
       .find("button")
       .should("be.visible")
       .click();
     cy.get('input[name="email"]').clear();
-    cy.get('input[name="email"]').type("newEmail@gmail.com");
+    cy.get('input[name="email"]').type(newEmail);
     cy.get('button[type="submit"]').click();
-    cy.contains("newUsername").should("be.visible");
+    cy.contains(newEmail).should("be.visible");
     cy.location("pathname").should("eq", "/profile/settings");
   });
 
   it("Try to change password in the profile page without value", () => {
-    cy.login("newEmail@gmail.com", newUser.password);
+    cy.login(newEmail, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(2)
       .should("be.visible")
       .find("button")
@@ -178,13 +180,13 @@ describe("Profile page tests", () => {
   });
 
   it("Try to change password in the profile page to something that doesnt meet the requirements", () => {
-    cy.login("newEmail@gmail.com", newUser.password);
+    cy.login(newEmail, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(2)
       .should("be.visible")
       .find("button")
@@ -197,13 +199,13 @@ describe("Profile page tests", () => {
   });
 
   it("Change password succeessfully in the profile page", () => {
-    cy.login("newEmail@gmail.com", newUser.password);
+    cy.login(newEmail, newUser.password);
     cy.visit("/profile/settings");
-    cy.get(".profile-card-right")
-      .find(".profile-card-content-divider")
+    cy.get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(2)
       .should("be.visible")
       .find("button")
@@ -215,14 +217,14 @@ describe("Profile page tests", () => {
   });
 
   it("Delete user confirmation modal in the profile page and press cancel", () => {
-    cy.login("newEmail@gmail.com", "Newpassword1!");
+    cy.login(newEmail, "Newpassword1!");
     cy.visit("/profile/settings");
     cy
-      .get(".profile-card-right")
-      .find(".profile-card-content-divider")
+      .get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(3)
       .should("be.visible")
       .find("button")
@@ -235,14 +237,14 @@ describe("Profile page tests", () => {
   });
 
   it("Delete user confirmation modal in the profile page and successfully delete user", () => {
-    cy.login("newEmail@gmail.com", "Newpassword1!");
+    cy.login(newEmail, "Newpassword1!");
     cy.visit("/profile/settings");
     cy
-      .get(".profile-card-right")
-      .find(".profile-card-content-divider")
+      .get(".profile-settings-right")
+      .find(".profile-settings-divider")
       .first()
       .should("be.visible")
-      .find(".profile-card-element")
+      .find(".profile-settings-wrapper")
       .eq(3)
       .should("be.visible")
       .find("button")

--- a/frontend/sass/base/_typography.scss
+++ b/frontend/sass/base/_typography.scss
@@ -3,17 +3,6 @@
 @use "../abstracts/" as abstracts;
 
 // Titles
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: abstracts.$default-title-font;
-  line-height: abstracts.$default-line-height;
-  letter-spacing: abstracts.$title-letter-spacing;
-}
-
 h1 {
   font-size: abstracts.$h1-font-size;
   font-weight: 400;
@@ -43,6 +32,48 @@ h6 {
   letter-spacing: 0;
   font-size: abstracts.$h6-font-size;
   font-weight: 300;
+}
+
+.h1 {
+  font-size: abstracts.$h1-font-size;
+  font-weight: 400;
+}
+
+.h2 {
+  font-size: abstracts.$h2-font-size;
+  font-weight: 400;
+}
+
+.h3 {
+  font-size: abstracts.$h3-font-size;
+  font-weight: 300;
+}
+
+.h4 {
+  font-size: abstracts.$h4-font-size;
+  font-weight: 300;
+}
+
+.h5 {
+  font-size: abstracts.$h5-font-size;
+  font-weight: 400;
+}
+
+.h6 {
+  letter-spacing: 0;
+  font-size: abstracts.$h6-font-size;
+  font-weight: 300;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: abstracts.$default-title-font;
+  line-height: abstracts.$default-line-height;
+  letter-spacing: abstracts.$title-letter-spacing;
 }
 
 // Links

--- a/frontend/sass/base/_typography.scss
+++ b/frontend/sass/base/_typography.scss
@@ -3,68 +3,6 @@
 @use "../abstracts/" as abstracts;
 
 // Titles
-h1 {
-  font-size: abstracts.$h1-font-size;
-  font-weight: 400;
-}
-
-h2 {
-  font-size: abstracts.$h2-font-size;
-  font-weight: 400;
-}
-
-h3 {
-  font-size: abstracts.$h3-font-size;
-  font-weight: 300;
-}
-
-h4 {
-  font-size: abstracts.$h4-font-size;
-  font-weight: 300;
-}
-
-h5 {
-  font-size: abstracts.$h5-font-size;
-  font-weight: 400;
-}
-
-h6 {
-  letter-spacing: 0;
-  font-size: abstracts.$h6-font-size;
-  font-weight: 300;
-}
-
-.h1 {
-  font-size: abstracts.$h1-font-size;
-  font-weight: 400;
-}
-
-.h2 {
-  font-size: abstracts.$h2-font-size;
-  font-weight: 400;
-}
-
-.h3 {
-  font-size: abstracts.$h3-font-size;
-  font-weight: 300;
-}
-
-.h4 {
-  font-size: abstracts.$h4-font-size;
-  font-weight: 300;
-}
-
-.h5 {
-  font-size: abstracts.$h5-font-size;
-  font-weight: 400;
-}
-
-.h6 {
-  letter-spacing: 0;
-  font-size: abstracts.$h6-font-size;
-  font-weight: 300;
-}
-
 h1,
 h2,
 h3,
@@ -74,6 +12,43 @@ h6 {
   font-family: abstracts.$default-title-font;
   line-height: abstracts.$default-line-height;
   letter-spacing: abstracts.$title-letter-spacing;
+}
+
+h1,
+.h1 {
+  font-size: abstracts.$h1-font-size;
+  font-weight: 400;
+}
+
+h2,
+.h2 {
+  font-size: abstracts.$h2-font-size;
+  font-weight: 400;
+}
+
+h3,
+.h3 {
+  font-size: abstracts.$h3-font-size;
+  font-weight: 400;
+}
+
+h4,
+.h4 {
+  font-size: abstracts.$h4-font-size;
+  font-weight: 300;
+}
+
+h5,
+.h5 {
+  font-size: abstracts.$h5-font-size;
+  font-weight: 400;
+}
+
+h6,
+.h6 {
+  letter-spacing: 0;
+  font-size: abstracts.$h6-font-size;
+  font-weight: 300;
 }
 
 // Links
@@ -153,6 +128,7 @@ p {
   font-weight: 300;
   font-style: italic;
   line-height: abstracts.$default-line-height;
+  margin-bottom: 10px;
 }
 .yellow-name-header {
   font-family: abstracts.$default-title-font;

--- a/frontend/sass/base/_typography.scss
+++ b/frontend/sass/base/_typography.scss
@@ -123,15 +123,6 @@ p {
   font-style: italic;
   line-height: abstracts.$default-line-height;
 }
-.profile-card-label {
-  grid-column: auto / span 2;
-  font-size: abstracts.$h3-font-size;
-  font-weight: 300;
-  font-family: var(--font-poppins);
-  line-height: 1.6;
-  letter-spacing: -0.05rem;
-}
-
 .yellow-name-header {
   font-family: abstracts.$default-title-font;
   line-height: abstracts.$default-line-height;

--- a/frontend/sass/components/_dropdown.scss
+++ b/frontend/sass/components/_dropdown.scss
@@ -28,6 +28,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 10px;
+    margin: 0;
     border: 1px solid abstracts.$primary-dark;
 
     &:focus-visible {

--- a/frontend/sass/components/_form.scss
+++ b/frontend/sass/components/_form.scss
@@ -33,7 +33,10 @@ input[type="text"],
 input[type="password"],
 input[type="email"] {
   padding: 5px 10px;
-  padding-right: 30px;
+}
+
+input[type="password"] {
+  padding-right: 40px;
 }
 
 textarea {

--- a/frontend/sass/components/_modal.scss
+++ b/frontend/sass/components/_modal.scss
@@ -4,7 +4,7 @@
 .modal-background {
   display: flex;
   position: fixed;
-  background-color: rgba(abstracts.$primary-dark, 0.5);
+  background-color: rgba(abstracts.$primary-dark, 0.75);
   justify-content: center;
   align-items: center;
   left: 0;
@@ -21,7 +21,7 @@
   overflow: hidden;
   color: white;
   width: 700px;
-  min-height: 400px;
+  min-height: fit-content;
   box-shadow: abstracts.$default-shadow;
 
   a {
@@ -30,7 +30,7 @@
 }
 
 .modal-title {
-  background-color: abstracts.$primary-dark;
+  background-color: abstracts.$primary-darkgrey;
   display: flex;
   justify-content: flex-end;
   padding: 5px 10px;
@@ -51,7 +51,7 @@
 }
 
 .modal-footer {
-  background-color: abstracts.$primary-dark;
+  background-color: abstracts.$primary-darkgrey;
   display: flex;
   justify-self: flex-end;
   padding: 10px;

--- a/frontend/sass/components/_modal.scss
+++ b/frontend/sass/components/_modal.scss
@@ -22,6 +22,7 @@
   color: white;
   width: 700px;
   min-height: 400px;
+  box-shadow: abstracts.$default-shadow;
 
   a {
     padding: 0;
@@ -29,7 +30,7 @@
 }
 
 .modal-title {
-  background-color: abstracts.$primary-darkgrey;
+  background-color: abstracts.$primary-dark;
   display: flex;
   justify-content: flex-end;
   padding: 5px 10px;
@@ -50,7 +51,7 @@
 }
 
 .modal-footer {
-  background-color: abstracts.$primary-darkgrey;
+  background-color: abstracts.$primary-dark;
   display: flex;
   justify-self: flex-end;
   padding: 10px;

--- a/frontend/sass/components/_section.scss
+++ b/frontend/sass/components/_section.scss
@@ -21,3 +21,8 @@
   background-color: abstracts.$primary-grey;
   padding: 15px;
 }
+
+.section-wrapper {
+  display: grid;
+  gap: 40px;
+}

--- a/frontend/sass/pages/_home.scss
+++ b/frontend/sass/pages/_home.scss
@@ -1,10 +1,5 @@
 @use "../abstracts" as abstracts;
 
-.home-content {
-  padding: 10px 20px;
-  display: grid;
-}
-
 .poster-list {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -21,6 +16,7 @@
   height: auto;
   width: 100%;
   box-shadow: abstracts.$default-shadow;
+  border: abstracts.$default-border;
 }
 
 .poster:hover {
@@ -32,17 +28,15 @@
 .dropdown-button {
   display: flex;
   align-items: center;
-  float: right;
-  padding-bottom: 10px;
-  justify-content: space-between;
-  width: 200px;
+  justify-content: flex-end;
   gap: 5px;
-  margin-right: 4px;
+  width: 100%;
 }
 
 .dropdown-menu {
   z-index: 100;
 }
+
 .dropdown-item {
   cursor: pointer;
 }

--- a/frontend/sass/pages/_index.scss
+++ b/frontend/sass/pages/_index.scss
@@ -2,5 +2,5 @@
 @forward "./_movies";
 @forward "./_notFound";
 @forward "./_persons";
-@forward "./profile";
+@forward "./profileSettings";
 @forward "./userProfile";

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -62,6 +62,9 @@
     font-family: abstracts.$default-title-font;
     font-weight: 400;
     letter-spacing: -0.025rem;
+    padding: 5px 10px;
+    background-color: rgba(abstracts.$primary-darkgrey, 0.5);
+    border-radius: abstracts.$default-border-radius;
   }
 
   .profile-settings-input {
@@ -72,6 +75,10 @@
     input,
     p {
       width: 100%;
+    }
+
+    p {
+      padding: 5px 10px;
     }
 
     button {

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -1,56 +1,93 @@
 @use "sass:map";
 @use "../abstracts" as abstracts;
 
-.profile-card-left {
-  margin-left: 10%;
-}
-.profile-card-right {
-  margin-left: 15%;
-}
-.profile-card-modal-content {
-  display: flex;
-  flex-flow: wrap;
+.profile-settings {
+  display: inline-flex;
   justify-content: center;
-  margin-bottom: 25%;
-}
-.profile-card-modal-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-}
-
-.profile-card {
-  display: grid;
-  grid-template-columns: auto auto;
-  justify-content: center;
+  gap: 40px;
+  width: 100%;
 
   textarea {
     resize: none;
   }
 }
-.profile-card-social-media {
+
+.profile-settings-social-media {
   display: grid;
-  grid-template-columns: auto auto;
   align-items: center;
   gap: 5px;
-  svg:nth-child(1) {
+
+  .social-media-row {
+    display: inline-flex;
+    gap: 10px;
+  }
+
+  .pink > svg {
     color: map.get(map.get(abstracts.$highlight-colors, "pink"), "default");
   }
-  svg:nth-child(3) {
+
+  .yellow > svg {
     color: map.get(map.get(abstracts.$highlight-colors, "yellow"), "default");
   }
-  svg:nth-child(5) {
+
+  .cyan > svg {
     color: map.get(map.get(abstracts.$highlight-colors, "cyan"), "default");
   }
 }
-.profile-card-element {
-  display: grid;
-  grid-template-columns: 90% auto;
+
+.profile-settings-wrapper {
+  display: flex;
+  flex-direction: column;
+
+  label {
+    min-width: 100%;
+    font-size: abstracts.$h5-font-size;
+    font-family: abstracts.$default-title-font;
+    font-weight: 400;
+    letter-spacing: -0.025rem;
+  }
+
+  .profile-settings-input {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+
+    input,
+    p {
+      width: 100%;
+    }
+
+    button {
+      max-width: fit-content;
+    }
+  }
 }
-.profile-card-content-divider {
-  margin-bottom: 5%;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid;
-  border-color: abstracts.$primary-darkgrey;
+
+.profile-settings-divider {
+  padding: 20px 0;
+}
+
+.profile-settings-divider:not(:last-child) {
+  border-bottom: 1px solid abstracts.$primary-darkgrey;
+}
+
+@media only screen and (max-width: abstracts.$medium-width) {
+  .profile-settings {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.profile-settings-modal-content {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: center;
+  min-height: 100%;
+  margin-bottom: 25%;
+}
+
+.profile-settings-modal-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
 }

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -3,13 +3,28 @@
 
 .profile-settings {
   display: inline-flex;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 40px;
+  padding: 20px 40px;
   width: 100%;
 
   textarea {
     resize: none;
   }
+}
+
+.profile-settings-left {
+  flex: 1;
+  max-width: 400px;
+
+  & > svg {
+    width: 100%;
+  }
+}
+
+.profile-settings-right {
+  flex: 1;
+  max-width: 800px;
 }
 
 .profile-settings-social-media {
@@ -19,6 +34,7 @@
 
   .social-media-row {
     display: inline-flex;
+    align-items: center;
     gap: 10px;
   }
 
@@ -71,10 +87,17 @@
   border-bottom: 1px solid abstracts.$primary-darkgrey;
 }
 
-@media only screen and (max-width: abstracts.$medium-width) {
+@media only screen and (max-width: abstracts.$large-width) {
   .profile-settings {
     display: flex;
     flex-direction: column;
+  }
+
+  .profile-settings-left {
+    width: 100%;
+    max-width: 500px;
+    margin: auto;
+    flex: 0;
   }
 }
 

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -102,15 +102,16 @@
 }
 
 .profile-settings-modal-content {
-  display: flex;
+  display: grid;
   flex-flow: wrap;
-  justify-content: center;
-  min-height: 100%;
-  margin-bottom: 25%;
+  text-align: center;
+  gap: 40px;
+  margin: auto auto;
 }
 
 .profile-settings-modal-buttons {
   display: flex;
+  flex-direction: row;
   justify-content: center;
   gap: 10px;
 }

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -91,6 +91,7 @@
   .profile-settings {
     display: flex;
     flex-direction: column;
+    padding: 20px;
   }
 
   .profile-settings-left {

--- a/frontend/sass/pages/_profile.scss
+++ b/frontend/sass/pages/_profile.scss
@@ -16,6 +16,7 @@
 .profile-settings-left {
   flex: 1;
   max-width: 400px;
+  padding: 0 20px;
 
   & > svg {
     width: 100%;
@@ -99,6 +100,7 @@
     max-width: 500px;
     margin: auto;
     flex: 0;
+    padding: 0;
   }
 }
 

--- a/frontend/sass/pages/_profileSettings.scss
+++ b/frontend/sass/pages/_profileSettings.scss
@@ -2,11 +2,11 @@
 @use "../abstracts" as abstracts;
 
 .profile-settings {
-  display: inline-flex;
-  justify-content: flex-start;
+  display: flex;
   gap: 40px;
   padding: 20px 40px;
-  width: 100%;
+  width: fit-content;
+  margin: auto;
 
   textarea {
     resize: none;
@@ -100,7 +100,6 @@
     width: 100%;
     max-width: 400px;
     margin: auto;
-    flex: 0;
     padding: 0;
   }
 }

--- a/frontend/sass/pages/_profileSettings.scss
+++ b/frontend/sass/pages/_profileSettings.scss
@@ -15,7 +15,7 @@
 
 .profile-settings-left {
   flex: 1;
-  max-width: 400px;
+  max-width: 300px;
   padding: 0 20px;
 
   & > svg {
@@ -62,9 +62,6 @@
     font-family: abstracts.$default-title-font;
     font-weight: 400;
     letter-spacing: -0.025rem;
-    padding: 5px 10px;
-    background-color: rgba(abstracts.$primary-darkgrey, 0.5);
-    border-radius: abstracts.$default-border-radius;
   }
 
   .profile-settings-input {
@@ -77,12 +74,9 @@
       width: 100%;
     }
 
-    p {
-      padding: 5px 10px;
-    }
-
     button {
       max-width: fit-content;
+      margin: 0;
     }
   }
 }
@@ -95,7 +89,7 @@
   border-bottom: 1px solid abstracts.$primary-darkgrey;
 }
 
-@media only screen and (max-width: abstracts.$large-width) {
+@media only screen and (max-width: abstracts.$medium-width) {
   .profile-settings {
     display: flex;
     flex-direction: column;
@@ -104,7 +98,7 @@
 
   .profile-settings-left {
     width: 100%;
-    max-width: 500px;
+    max-width: 400px;
     margin: auto;
     flex: 0;
     padding: 0;

--- a/frontend/sass/pages/_profileSettings.scss
+++ b/frontend/sass/pages/_profileSettings.scss
@@ -25,7 +25,6 @@
 .profile-settings-right {
   flex: 1;
   width: 100%;
-  margin: auto;
 }
 
 .profile-settings-social-media {
@@ -77,7 +76,7 @@
 
     p,
     input {
-      max-width: 600px;
+      max-width: 700px;
       width: 100%;
     }
 

--- a/frontend/sass/pages/_profileSettings.scss
+++ b/frontend/sass/pages/_profileSettings.scss
@@ -5,8 +5,7 @@
   display: flex;
   gap: 40px;
   padding: 20px 40px;
-  width: fit-content;
-  margin: auto;
+  width: 100%;
 
   textarea {
     resize: none;
@@ -25,7 +24,8 @@
 
 .profile-settings-right {
   flex: 1;
-  max-width: 800px;
+  width: 100%;
+  margin: auto;
 }
 
 .profile-settings-social-media {
@@ -69,8 +69,15 @@
     align-items: center;
     gap: 10px;
 
-    input,
-    p {
+    .password-input-wrapper {
+      position: relative;
+      max-width: 600px;
+      width: 100%;
+    }
+
+    p,
+    input {
+      max-width: 600px;
       width: 100%;
     }
 

--- a/frontend/sass/pages/_profileSettings.scss
+++ b/frontend/sass/pages/_profileSettings.scss
@@ -5,7 +5,8 @@
   display: flex;
   gap: 40px;
   padding: 20px 40px;
-  width: 100%;
+  width: fit-content;
+  margin: auto;
 
   textarea {
     resize: none;
@@ -13,9 +14,9 @@
 }
 
 .profile-settings-left {
-  flex: 1;
+  width: 100%;
   max-width: 300px;
-  padding: 0 20px;
+  min-width: 200px;
 
   & > svg {
     width: 100%;
@@ -23,8 +24,8 @@
 }
 
 .profile-settings-right {
-  flex: 1;
   width: 100%;
+  min-width: 300px;
 }
 
 .profile-settings-social-media {
@@ -66,16 +67,19 @@
   .profile-settings-input {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
+    gap: 5px;
 
     .password-input-wrapper {
       position: relative;
-      max-width: 600px;
-      width: 100%;
+
+      input {
+        padding-right: 40px;
+      }
     }
 
     p,
-    input {
+    input,
+    .password-input-wrapper {
       max-width: 700px;
       width: 100%;
     }


### PR DESCRIPTION
### ⭐ New
- Add responsivity to User settings page
- Add classes that can be used to overwrite heading styles with others so headings can be used as they should

### ✏️ Changes
- Rename CSS classes
- Rename profile.scss to profileSettings.scss
- Make modal more visible with shadow and darker bg
- Fix dropdown menu margin
- Add show password toggle to user settings page
- Fix front page as space between sections disappeared after branch merge
- Fix showing only "-" when person doesn't have both birthday and deathday